### PR TITLE
translate State of JS 2021 into Japanese

### DIFF
--- a/accounts.yml
+++ b/accounts.yml
@@ -53,11 +53,11 @@ translations:
     - key: accounts.sign_up
       t: サインアップ
     - key: accounts.sign_in
-      t: Log in
+      t: ログイン
     - key: accounts.switch_to_sign_up
-      t: Don't have an account ? Sign up
+      t: アカウントがありませんか？サインアップしましょう
     - key: accounts.switch_to_sign_in
-      t: Already have an account? Log in
+      t: アカウントがありますか？ログインしてください
     - key: accounts.sign_out
       t: ログアウト
     - key: accounts.cancel

--- a/accounts.yml
+++ b/accounts.yml
@@ -53,7 +53,11 @@ translations:
     - key: accounts.sign_up
       t: サインアップ
     - key: accounts.sign_in
-      t: ログイン
+      t: Log in
+    - key: accounts.switch_to_sign_up
+      t: Don't have an account ? Sign up
+    - key: accounts.switch_to_sign_in
+      t: Already have an account? Log in
     - key: accounts.sign_out
       t: ログアウト
     - key: accounts.cancel

--- a/common.yml
+++ b/common.yml
@@ -1020,13 +1020,13 @@ translations:
     - key: tools_others.non_js_languages.others.description
       t: そのほかの回答（自由入力欄）。
     - key: tools_others.javascript_flavors
-      t: JavaScript Flavors
+      t: JavaScriptフレーバー
     - key: tools_others.javascript_flavors.description
-      t: Languages that compile to JavaScript
+      t: JavaScriptにコンパイルする言語
     - key: tools_others.javascript_flavors.others
-      t: Other JavaScript Flavors
+      t: そのほかのJavaScriptフレーバー
     - key: tools_others.javascript_flavors.others.description
-      t: Other answers (freeform field).
+      t: そのほかの回答（自由入力欄）。
 
 
 

--- a/common.yml
+++ b/common.yml
@@ -31,7 +31,7 @@ translations:
       t: >
           <a href="{link}">メインページへ戻る</a>。アンケートへの回答や、回答中のアンケートを再開できます。
     - key: general.take_survey
-      t: '{name} {year}に回答する'
+      t: '{name}に回答する'
 
     # surveys
     - key: general.open_surveys
@@ -74,6 +74,8 @@ translations:
       t: 翻訳協力
     - key: general.newly_added
       t: 今回追加された新しい項目
+    - key: general.new
+      t: New
 
     # credits
     - key: credits.thanks
@@ -1017,6 +1019,16 @@ translations:
       t: そのほかの言語
     - key: tools_others.non_js_languages.others.description
       t: そのほかの回答（自由入力欄）。
+    - key: tools_others.javascript_flavors
+      t: JavaScript Flavors
+    - key: tools_others.javascript_flavors.description
+      t: Languages that compile to JavaScript
+    - key: tools_others.javascript_flavors.others
+      t: Other JavaScript Flavors
+    - key: tools_others.javascript_flavors.others.description
+      t: Other answers (freeform field).
+
+
 
     ###########################################################################
     # Resources

--- a/state_of_css.yml
+++ b/state_of_css.yml
@@ -773,4 +773,4 @@ translations:
     - key: resources.first_steps
       t: CSSの最初の勉強方法
     - key: resources.first_steps.description
-      t: 最初にCSSを学び始めたとき、何から学びましたか。
+      t: 最初にCSSを学び始めたとき、どの方法で学びましたか。

--- a/state_of_css_2021_results.yml
+++ b/state_of_css_2021_results.yml
@@ -287,11 +287,13 @@ translations:
       t: |
             Miriam is an artist and an activist who creates software and art that celebrate the queer complexity of human experience. She's a CSS expert, and is doing an amazing job on the specifications for CSS Container Queries.
 
-    # - key: picks.sachagreif.bio
-    #   t: Creator of this survey
-    # - key: picks.sachagreif.description
-    #   t: |
-    #         With this blog post, Amelia Wattenberger didn't just go the extra mile, she ran a whole marathon! The animations and quiz will ensure you finally understand the CSS cascade. 
+    - key: picks.michebarks.name
+      t: “Building a Color Scheme” by Adam Argyle 
+    - key: picks.michebarks.bio
+      t: Senior Front End Developer
+    - key: picks.michebarks.description
+      t: |
+            I love this article because although custom properties have been around for a while now, it really takes them to a different level and showcases their power. I hope it makes some people think of them in a different way, as more than simple variables.
 
     # - key: picks.christianoliff.bio
     #   t: Front-end developer for Trimble MAPS

--- a/state_of_js.yml
+++ b/state_of_js.yml
@@ -84,9 +84,122 @@ translations:
     - key: sections.build_tools.description
       t: コードのコンパイルとビルド
 
+    - key: sections.monorepo_tools.title
+      t: Monorepo Tools
+    - key: sections.monorepo_tools.description
+      t: Tools used to manage JavaScript monorepos.
+
+    - key: sections.tools_others.title
+      t: Other Tools
+    - key: sections.tools_others.description
+      t: Other JavaScript tools
+
+    - key: sections.other_tools.title
+      t: Other Tools
+    - key: sections.other_tools.description
+      t: For these tools & technologies, just check the ones that you use regularly.
+
     ###########################################################################
     # Options
     ###########################################################################
+
+    # JS pain points
+    # - key: options.js_pain_points.browser_interoperability
+    #   t: Browser Compatibility
+    # - key: options.js_pain_points.browser_interoperability.description
+    #   t: Differences between Chrome, Safari, Firefox, etc.
+    # - key: options.js_pain_points.animations
+    #   t: Animations
+    # - key: options.js_pain_points.animations.description
+    #   t: Managing animations, transitions, etc. using JavaScript.
+    # - key: options.js_pain_points.form_handling
+    #   t: Form Handling
+    # - key: options.js_pain_points.form_handling.description
+    #   t: Creating forms, managing their state and errors, and saving their data. 
+    - key: options.js_pain_points.state_management
+      t: State Management
+    - key: options.js_pain_points.state_management.description
+      t: Managing global data state in complex applications. 
+    # - key: options.js_pain_points.performance_issues
+    #   t: Performance Issues
+    # - key: options.js_pain_points.performance_issues.description
+    #   t: Bundle sizes, slow loading, and other performance issues. 
+    - key: options.js_pain_points.managing_dependencies
+      t: Managing Dependencies
+    - key: options.js_pain_points.managing_dependencies.description
+      t: Managing dependencies, package versions and bundle sizes
+    - key: options.js_pain_points.architecture
+      t: Code Architecture
+    - key: options.js_pain_points.architecture.description
+      t: Organizing and maintaining your codebase.
+    - key: options.js_pain_points.finding_packages
+      t: Finding Packages
+    - key: options.js_pain_points.finding_packages.description
+      t: Finding and evaluating JavaScript packages.
+    - key: options.js_pain_points.writing_modules
+      t: Writing Modules
+    - key: options.js_pain_points.writing_modules.description
+      t: Writing JavaScript modules and publishing them as packages. 
+    - key: options.js_pain_points.debugging
+      t: Debugging
+    - key: options.js_pain_points.debugging.description
+      t: Identifying and solving issues with your code. 
+    - key: options.js_pain_points.async_code
+      t: Async Code
+    - key: options.js_pain_points.async_code.description
+      t: Handling asynchronous functions. 
+    - key: options.js_pain_points.modules_management
+      t: Modules Management
+    - key: options.js_pain_points.modules_management.description
+      t: Writing and importing modules. 
+    - key: options.js_pain_points.date_management
+      t: Date Management
+    - key: options.js_pain_points.date_management.description
+      t: Handling and manipulating dates and times. 
+    # - key: options.js_pain_points.xxx
+    #   t: 
+    # - key: options.js_pain_points.xxx.description
+    #   t: 
+
+
+    # JS missing features
+    - key: options.currently_missing_from_js.static_typing
+      t: Static Typing
+    - key: options.currently_missing_from_js.static_typing.description
+      t: Native types (similar to what TypeScript offers).
+    - key: options.currently_missing_from_js.standard_library
+      t: Standard Library
+    - key: options.currently_missing_from_js.standard_library.description
+      t: A standard library of common utilities
+    - key: options.currently_missing_from_js.pattern_matching
+      t: Pattern Matching
+    - key: options.currently_missing_from_js.pattern_matching.description
+      t: A new `match` keyword for pattern-matching objects. 
+    - key: options.currently_missing_from_js.pipe_operator
+      t: Pipe Operator
+    - key: options.currently_missing_from_js.pipe_operator.description
+      t: A new `|>` operator for passing the result of one function to another.
+    - key: options.currently_missing_from_js.decorators
+      t: Decorators
+    - key: options.currently_missing_from_js.decorators.description
+      t: Decorators used to metaprogram and add functionality to a value.
+    - key: options.currently_missing_from_js.immutable_data_structures
+      t: Immutable Data Structures
+    - key: options.currently_missing_from_js.immutable_data_structures.description
+      t: New deeply immutable data structures such as `Record` and `Tuple`.
+    - key: options.currently_missing_from_js.better_date_management
+      t: Better Date Management
+    - key: options.currently_missing_from_js.better_date_management.description
+      t: A new `Temporal` object for working with dates and times.
+    - key: options.currently_missing_from_js.observable
+      t: Observable
+    - key: options.currently_missing_from_js.observable.description
+      t: A new `Observable`` type used to model push-based data sources.
+    # - key: options.currently_missing_from_js.xxx
+    #   t: 
+    # - key: options.currently_missing_from_js.xxx.description
+    #   t: 
+
 
     ###########################################################################
     # Features
@@ -185,6 +298,22 @@ translations:
     - key: features.reactive_programming
       t: リアクティブプログラミング
 
+    # upcoming features
+    # - key: features.static_typing
+    #   t: Static Typing
+
+    # - key: features.standard_library
+    #   t: Standard Library
+
+    # - key: features.pattern_matching
+    #   t: Pattern Matching
+
+    # - key: features.pipe_operator
+    #   t: Pipe Operator
+
+    # - key: features.immutable_data_structures
+    #   t: Immutable Data Structures
+
     ###########################################################################
     # Tools
     ###########################################################################
@@ -213,6 +342,11 @@ translations:
       t: そのほかのパッケージレジストリ
     - key: tools_others.package_registries.others.description
       t: そのほかの回答（自由入力欄）
+
+    - key: tools_others.form_factors
+      aliasFor: environments.form_factors
+    - key: tools_others.form_factors.description
+      aliasFor: environments.form_factors.description
 
     ###########################################################################
     # Opinions
@@ -247,3 +381,29 @@ translations:
 
     - key: happiness.state_of_js
       t: JavaScriptの現状に満足していますか？
+
+    # Pain Points
+    - key: opinions.js_pain_points
+      t: JavaScript Pain Points
+    - key: opinions.js_pain_points.description
+      t: For each matchup, pick the aspect of JavaScript you struggle with the most.
+
+    - key: opinions_others.js_pain_points.others
+      t: Other JavaScript Pain Points
+
+    # Missing Features
+    - key: opinions.currently_missing_from_js
+      t: What do you feel is currently missing from JavaScript?
+    - key: opinions.currently_missing_from_js.description
+      t: For each matchup, pick the feature you'd most like to be able to use in JavaScript today.
+    - key: opinions_others.currently_missing_from_js.others
+      t: Other Missing Features
+
+    ###########################################################################
+    # Resources
+    ###########################################################################
+
+    - key: resources.first_steps
+      t: First Steps With JavaScript
+    - key: resources.first_steps.description
+      t: When first starting out, how did you initially learn JavaScript?

--- a/state_of_js.yml
+++ b/state_of_js.yml
@@ -186,7 +186,7 @@ translations:
     - key: options.currently_missing_from_js.immutable_data_structures
       t: イミュータブルなデータ構造
     - key: options.currently_missing_from_js.immutable_data_structures.description
-      t: `Record`や`Tuple`など、より徹底したイミュータブルなデータ構造。
+      t: '`Record`や`Tuple`など、より徹底したイミュータブルなデータ構造。'
     - key: options.currently_missing_from_js.better_date_management
       t: より良い日付管理
     - key: options.currently_missing_from_js.better_date_management.description

--- a/state_of_js.yml
+++ b/state_of_js.yml
@@ -85,19 +85,19 @@ translations:
       t: コードのコンパイルとビルド
 
     - key: sections.monorepo_tools.title
-      t: Monorepo Tools
+      t: モノレポのツール
     - key: sections.monorepo_tools.description
-      t: Tools used to manage JavaScript monorepos.
+      t: JavaScriptモノレポの管理に使うツール
 
     - key: sections.tools_others.title
-      t: Other Tools
+      t: そのほかのツール
     - key: sections.tools_others.description
-      t: Other JavaScript tools
+      t: そのほかのJavaScriptツール
 
     - key: sections.other_tools.title
-      t: Other Tools
+      t: そのほかのツール
     - key: sections.other_tools.description
-      t: For these tools & technologies, just check the ones that you use regularly.
+      t: 以下のツールや技術について、普段使っているものにチェックをつけてください
 
     ###########################################################################
     # Options
@@ -117,45 +117,45 @@ translations:
     # - key: options.js_pain_points.form_handling.description
     #   t: Creating forms, managing their state and errors, and saving their data. 
     - key: options.js_pain_points.state_management
-      t: State Management
+      t: ステート管理
     - key: options.js_pain_points.state_management.description
-      t: Managing global data state in complex applications. 
+      t: 複雑なアプリケーションで、グローバルなデータのステートを管理すること。
     # - key: options.js_pain_points.performance_issues
     #   t: Performance Issues
     # - key: options.js_pain_points.performance_issues.description
     #   t: Bundle sizes, slow loading, and other performance issues. 
     - key: options.js_pain_points.managing_dependencies
-      t: Managing Dependencies
+      t: 依存関係の管理
     - key: options.js_pain_points.managing_dependencies.description
-      t: Managing dependencies, package versions and bundle sizes
+      t: 依存関係やパッケージのバージョン、バンドルサイズを管理すること。
     - key: options.js_pain_points.architecture
-      t: Code Architecture
+      t: コード設計
     - key: options.js_pain_points.architecture.description
-      t: Organizing and maintaining your codebase.
+      t: コードベースを構造化したり管理すること。
     - key: options.js_pain_points.finding_packages
-      t: Finding Packages
+      t: パッケージの検索
     - key: options.js_pain_points.finding_packages.description
-      t: Finding and evaluating JavaScript packages.
+      t: JavaScriptパッケージを探したり評価すること。
     - key: options.js_pain_points.writing_modules
-      t: Writing Modules
+      t: モジュールの作成
     - key: options.js_pain_points.writing_modules.description
-      t: Writing JavaScript modules and publishing them as packages. 
+      t: JavaScriptモジュールを作成したり、パッケージとして公開すること。
     - key: options.js_pain_points.debugging
-      t: Debugging
+      t: デバッグ
     - key: options.js_pain_points.debugging.description
-      t: Identifying and solving issues with your code. 
+      t: コードの問題点を見つけたり、解決すること。
     - key: options.js_pain_points.async_code
-      t: Async Code
+      t: 非同期処理
     - key: options.js_pain_points.async_code.description
-      t: Handling asynchronous functions. 
+      t: 非同期な関数を処理すること。
     - key: options.js_pain_points.modules_management
-      t: Modules Management
+      t: モジュール管理
     - key: options.js_pain_points.modules_management.description
-      t: Writing and importing modules. 
+      t: モジュールを書いたり読み込んだりすること。
     - key: options.js_pain_points.date_management
-      t: Date Management
+      t: 日付や時刻の処理
     - key: options.js_pain_points.date_management.description
-      t: Handling and manipulating dates and times. 
+      t: 日付や時刻を処理したり操作すること。
     # - key: options.js_pain_points.xxx
     #   t: 
     # - key: options.js_pain_points.xxx.description
@@ -164,37 +164,37 @@ translations:
 
     # JS missing features
     - key: options.currently_missing_from_js.static_typing
-      t: Static Typing
+      t: 静的型付け
     - key: options.currently_missing_from_js.static_typing.description
-      t: Native types (similar to what TypeScript offers).
+      t: 型のネイティブサポート（TypeScriptと同様の機能）。
     - key: options.currently_missing_from_js.standard_library
-      t: Standard Library
+      t: 標準ライブラリ
     - key: options.currently_missing_from_js.standard_library.description
-      t: A standard library of common utilities
+      t: 共通ユーティリティの標準ライブラリ。
     - key: options.currently_missing_from_js.pattern_matching
-      t: Pattern Matching
+      t: パターンマッチ
     - key: options.currently_missing_from_js.pattern_matching.description
-      t: A new `match` keyword for pattern-matching objects. 
+      t: オブジェクトのパターンマッチに使う新しい`match`キーワード。
     - key: options.currently_missing_from_js.pipe_operator
-      t: Pipe Operator
+      t: パイプ演算子
     - key: options.currently_missing_from_js.pipe_operator.description
-      t: A new `|>` operator for passing the result of one function to another.
+      t: 関数の結果を別の関数に渡す新しい`|>`演算子。
     - key: options.currently_missing_from_js.decorators
-      t: Decorators
+      t: デコレータ
     - key: options.currently_missing_from_js.decorators.description
-      t: Decorators used to metaprogram and add functionality to a value.
+      t: メタプログラミングや値に処理を付加するデコレータ。
     - key: options.currently_missing_from_js.immutable_data_structures
-      t: Immutable Data Structures
+      t: イミュータブルなデータ構造
     - key: options.currently_missing_from_js.immutable_data_structures.description
-      t: New deeply immutable data structures such as `Record` and `Tuple`.
+      t: `Record`や`Tuple`など、より徹底したイミュータブルなデータ構造。
     - key: options.currently_missing_from_js.better_date_management
-      t: Better Date Management
+      t: より良い日付管理
     - key: options.currently_missing_from_js.better_date_management.description
-      t: A new `Temporal` object for working with dates and times.
+      t: 日付や時刻を処理するための新しい`Temporal`オブジェクト。
     - key: options.currently_missing_from_js.observable
       t: Observable
     - key: options.currently_missing_from_js.observable.description
-      t: A new `Observable`` type used to model push-based data sources.
+      t: プッシュベースなデータソースのモデリングに使う新しい型`Observable`。
     # - key: options.currently_missing_from_js.xxx
     #   t: 
     # - key: options.currently_missing_from_js.xxx.description
@@ -227,19 +227,19 @@ translations:
     - key: features.optional_chaining.description
       t: '例：`const dogName = adventurer.dog?.name`'
     - key: features.private_fields
-      t: Private Fields
+      t: プライベートフィールド
     - key: features.private_fields.description
       t: '例：`class ClassWithPrivateField { #privateField }`'
 
     # language
     - key: features.proxies
-      t: Proxies
+      t: Proxy
     - key: features.async_await
       t: Async/Await
     - key: features.promises
-      t: Promises
+      t: Promise
     - key: features.decorators
-      t: Decorators
+      t: デコレータ
     - key: features.decorators.description
       t: デコレータを簡単に言うと、コードの一部を別のコードでラップする（文字通り「デコレート」する）仕組みです。
     - key: features.dynamic_import
@@ -250,11 +250,11 @@ translations:
 
     # data structures
     - key: features.maps
-      t: Maps
+      t: Map
     - key: features.sets
-      t: Sets
+      t: Set
     - key: features.typed_arrays
-      t: Typed Arrays
+      t: Typed Array
     - key: array_prototype_flat
       t: Array.prototype.flat
 
@@ -384,26 +384,26 @@ translations:
 
     # Pain Points
     - key: opinions.js_pain_points
-      t: JavaScript Pain Points
+      t: JavaScriptのつらいところ
     - key: opinions.js_pain_points.description
-      t: For each matchup, pick the aspect of JavaScript you struggle with the most.
+      t: JavaScriptどんなところで苦労するか、対決させてください。
 
     - key: opinions_others.js_pain_points.others
-      t: Other JavaScript Pain Points
+      t: そのほかのJavaScriptのつらいところ
 
     # Missing Features
     - key: opinions.currently_missing_from_js
-      t: What do you feel is currently missing from JavaScript?
+      t: どんな機能がJavaScriptに足りてないと思いますか？
     - key: opinions.currently_missing_from_js.description
-      t: For each matchup, pick the feature you'd most like to be able to use in JavaScript today.
+      t: JavaScriptにあれば今すぐ使いたいと思う機能について、対決させてください。
     - key: opinions_others.currently_missing_from_js.others
-      t: Other Missing Features
+      t: そのほかでほしい機能
 
     ###########################################################################
     # Resources
     ###########################################################################
 
     - key: resources.first_steps
-      t: First Steps With JavaScript
+      t: JavaScriptの最初の勉強方法
     - key: resources.first_steps.description
-      t: When first starting out, how did you initially learn JavaScript?
+      t: 最初にJavaScriptを学び始めたとき、どの方法で学びましたか。

--- a/state_of_js_2021_survey.yml
+++ b/state_of_js_2021_survey.yml
@@ -1,0 +1,21 @@
+locale: en-US
+namespace: js
+translations:
+    ###########################################################################
+    # General
+    ###########################################################################
+
+    - key: general.survey_intro_js2021
+      t: >
+          First the 2020 Olympics got pushed back to 2021, 
+          and now the 2021 State of JavaScript survey is happening now, in 2022!
+
+
+          It's true: between work, family, and and all the turmoil in the world, 
+          some things got disrupted a little.
+          
+
+          But while the year may be off-by-one, we hope the data provided by the 
+          survey itself will be just as informative and insightful as ever. 
+          And don't worry, there will be another survey towards the end of this year to set things straight again!
+          

--- a/state_of_js_2021_survey.yml
+++ b/state_of_js_2021_survey.yml
@@ -1,4 +1,4 @@
-locale: en-US
+locale: ja-JP
 namespace: js
 translations:
     ###########################################################################
@@ -7,15 +7,11 @@ translations:
 
     - key: general.survey_intro_js2021
       t: >
-          First the 2020 Olympics got pushed back to 2021, 
-          and now the 2021 State of JavaScript survey is happening now, in 2022!
+          2020年のオリンピックが2021年に延期されたように、2021年のState of JavaScriptもこの2022年に行われることとなったのです！
 
 
-          It's true: between work, family, and and all the turmoil in the world, 
-          some things got disrupted a little.
-          
+          ええ。そうです。仕事、家族、世界中で起こっている混乱すべてに挟まれて、ちょっとはみ出てしまったんです。
 
-          But while the year may be off-by-one, we hope the data provided by the 
-          survey itself will be just as informative and insightful as ever. 
-          And don't worry, there will be another survey towards the end of this year to set things straight again!
-          
+
+          これもoff-by-oneエラーなのかもしれませんね。でも、このアンケートのデータが引き続き、真実を見据えた有益なものであると願っています。
+          心配しないでください。今年は年末にアンケートをやって、一年をきれいに終わらせられるでしょう！


### PR DESCRIPTION
this adds translation for newly added strings in the locale-en-US for the past couple days.
https://github.com/StateOfJS/locale-en-US/compare/3b08fba59a83c3b8b7e55c8ded3d7fe963d4a39d...0ed4718ca5fb7ac55003f63a165b765cb64e9aff